### PR TITLE
fix: remove HostListener from _handleClick; fixes #27

### DIFF
--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-header/mat-multi-sort-header.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-header/mat-multi-sort-header.component.ts
@@ -56,6 +56,7 @@ export class MatMultiSortHeaderComponent extends MatSortHeader {
   }
 
   _handleClick() {
+    this._sort.direction = this.getSortDirection();
     super._handleClick();
   }
 

--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-header/mat-multi-sort-header.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-header/mat-multi-sort-header.component.ts
@@ -55,7 +55,6 @@ export class MatMultiSortHeaderComponent extends MatSortHeader {
     super._setIndicatorHintVisible(visible as boolean);
   }
 
-  @HostListener('click')
   _handleClick() {
     super._handleClick();
   }


### PR DESCRIPTION
As stated in #27, `_handleClick` is being called twice.
Consequently, `matSortChange` is being called twice too. These two calls have different values for `sort.actives` and `sort.directions`.
I've removed the `HostListener` and everything seems to be working correctly.