### PR TITLE
Fix dialog window position problem.

### DIFF
--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
@@ -41,8 +41,8 @@ export class MatMultiSortTableSettingsComponent implements OnInit {
   openDialog() {
     if (this.dialogRef) { return; }
     const button = this.buttonRef.nativeElement;
-    const posRight: number = window.innerWidth - (button.offsetLeft + button.offsetWidth + 16);
-    const posTop: number = button.offsetTop + button.offsetHeight;
+    const posRight: number = window.innerWidth - (button.getBoundingClientRect().left + button.offsetWidth + 16);
+    const posTop: number = button.getBoundingClientRect().top + button.offsetHeight;
 
     this.dialogRef = this.dialog.open(MatMultiSortColumnDialogComponent, {
       backdropClass: 'cdk-overlay-transparent-backdrop',


### PR DESCRIPTION
Use getBoundingClientRect() instead of offsetLeft/offsetTop. 
Offsets take relative position, which causes problem if the table is nested in complex structure. Dialog window must be positioned absolutely to window, not relatively to parent element of the button which opens dialog.