### PR TITLE
Feature/custom sort indicator in chip list

### DIFF
--- a/projects/mat-multi-sort/README.md
+++ b/projects/mat-multi-sort/README.md
@@ -24,6 +24,10 @@ To run the demo:
 ![demo gif](demo.gif)
 
 ## Changelog
+### Version 0.6.0
+- Added support for custom content in the settings chip list (when icons are desired instead of 'asc | desc' labels i.g.)
+- Extended the example to showcase the icons as sort indicators instead of text labels
+
 ### Version 0.5.3
 - Fixed bug where position of settings dialog was calculated wrong, if placed in some nested element witch has a relative or absolute position. Thanks to [forbik0](https://github.com/forbik0).
 - Fixed bug where defaultSortParams could not get set via TableData constructor.
@@ -103,6 +107,11 @@ This is the datasource of the MultiSortTable, it works like the ` MatTableDataSo
     Spalten bearbeiten &nbsp;
     <mat-icon>menu</mat-icon>
   </button>
+  <!-- Optional custom content for the sort indicator chip (here column name with icons)  --> 
+  <ng-template #sortIndicator let-direction='direction' let-columnName='columnName'>
+    {{columnName}}
+    <mat-icon *ngIf="direction">{{direction === 'asc' ? 'arrow_upward' : 'arrow_downward'}}</mat-icon>
+  </ng-template>
 </mat-multi-sort-table-settings>
 <table mat-table [dataSource]="table.dataSource" matMultiSort (matSortChange)="table.onSortEvent()">
 

--- a/projects/mat-multi-sort/package.json
+++ b/projects/mat-multi-sort/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-multi-sort",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "A extension for the angular material table to support multi-sorting.",
   "author": "Maximilian Balluff",
   "repository": {

--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.html
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.html
@@ -4,9 +4,15 @@
             (cdkDropListDropped)="dropSort($event)">
             <mat-chip class="drag-chip" *ngFor="let item of sort" cdkDrag (removed)="remove(item.id)"
                 (click)="updateDirection(item.id)">
-                {{item.name}}:
-                <div class="sorting" [matTooltip]="sortToolTip">
-                    {{item.direction}}
+                <ng-container *ngIf="sortIndicatorRef"
+                              [ngTemplateOutlet]="sortIndicatorRef"
+                              [ngTemplateOutletContext]="{direction:item.direction, columnName: item.name }">
+                </ng-container>
+                <div *ngIf="!sortIndicatorRef">
+                    {{item.name}}:
+                    <div class="sorting" [matTooltip]="sortToolTip">
+                        {{item.direction}}
+                    </div>
                 </div>
                 <mat-icon matChipRemove>cancel</mat-icon>
             </mat-chip>

--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, ContentChild, ElementRef, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { TableData } from '../table-data';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -17,6 +17,8 @@ export class MatMultiSortTableSettingsComponent implements OnInit {
   dialogRef: MatDialogRef<any>;
 
   @ViewChild('settingsMenu') buttonRef: ElementRef;
+
+  @ContentChild('sortIndicator', { static: false }) sortIndicatorRef: TemplateRef<any>;
 
   @Input()
   sortToolTip: string;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,7 +8,6 @@
       user can select/deselect multiple items)</mat-checkbox>
   </p>
   <p>
-  <p>
     <mat-checkbox [(ngModel)]="TOGGLE_INDICATOR_ICONS">
       Toggle sort Indicator icons instead of text based labels
     </mat-checkbox>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,13 +7,23 @@
     <mat-checkbox [(ngModel)]="CLOSE_MENU_BEHAVIOR">Close settings menu on selection (if disabled it stays open, so the
       user can select/deselect multiple items)</mat-checkbox>
   </p>
+  <p>
+  <p>
+    <mat-checkbox [(ngModel)]="TOGGLE_INDICATOR_ICONS">
+      Toggle sort Indicator icons instead of text based labels
+    </mat-checkbox>
+  </p>
 </div>
 
 <div class="mat-elevation-z8" style="padding: 8px;">
-  <mat-multi-sort-table-settings [tableData]="table" sortToolTip="Sortierreihenfole ändern"
+  <mat-multi-sort-table-settings [tableData]="table" sortToolTip="Sortierreihenfolge ändern"
     [closeDialogOnChoice]="CLOSE_MENU_BEHAVIOR">
     <button mat-stroked-button> Spalten bearbeiten &nbsp; <mat-icon>menu</mat-icon>
     </button>
+    <ng-template *ngIf="TOGGLE_INDICATOR_ICONS"  #sortIndicator let-direction='direction' let-columnName='columnName'>
+      {{columnName}}
+      <mat-icon [matTooltip]="'Sortierreihenfolge ändern'" *ngIf="direction">{{direction === 'asc' ? 'arrow_upward' : 'arrow_downward'}}</mat-icon>
+    </ng-template>
   </mat-multi-sort-table-settings>
   <table mat-table [dataSource]="table.dataSource" matMultiSort (matSortChange)="table.onSortEvent()">
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { DummyService, UserData } from './dummy.service';
 export class AppComponent implements OnInit {
   CLIENT_SIDE = true;
   CLOSE_MENU_BEHAVIOR = true;
+  TOGGLE_INDICATOR_ICONS = false;
 
   table: TableData<UserData>;
   @ViewChild(MatMultiSort) sort: MatMultiSort;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { AppComponent } from './app.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MatMultiSortModule } from 'mat-multi-sort';
 import { FormsModule } from '@angular/forms';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [
@@ -35,7 +36,8 @@ import { FormsModule } from '@angular/forms';
     MatIconModule,
     MatDividerModule,
     MatCheckboxModule,
-    FormsModule
+    FormsModule,
+    MatTooltipModule
   ],
   providers: [],
   bootstrap: [AppComponent],


### PR DESCRIPTION
As mentioned in the issue https://github.com/Maxl94/ngx-multi-sort-table/issues/47, I would like to have the custom content feature for the chip list, so that one can add icons, or any text instead of the "columnName: 'asc | desc'" label

Best Regards
khalilof