### PR TITLE
Scroll strategy input

### DIFF
--- a/projects/mat-multi-sort/README.md
+++ b/projects/mat-multi-sort/README.md
@@ -81,6 +81,7 @@ The user can easyly change the sorting order by drag and drop the chips and also
 | tableData           | An input of `tableData` object which holds the complete table state                                                                                                                                                                      | @Input: TableData |
 | sortToolTip         | A input test for the tooltip to show up over the sorting chips                                                                                                                                                                           | @Input: string    |
 | closeDialogOnChoice | A input to control the behavior of the settings menu. If set to `true` the dialog closes after the user has selected a column, if `false` it stays open, so the user can select/deselect multiple columns with out reopening the dialog. | @Input: boolean   |
+| scrollStrategy      | An input of ScrollStrategy for the CDK overlay. Sets the behavior for scrolling when the dialog is opened. Possible options are the predefined strategies: Noop, Close, Block or Reposition, with Block being the default value.         | @Input: ScrollStrategy
 
 ### MatMultiSortTableDataSource
 This is the datasource of the MultiSortTable, it works like the ` MatTableDataSource`´.

--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
@@ -1,7 +1,7 @@
 import {Component, ContentChild, ElementRef, Input, OnInit, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import { TableData } from '../table-data';
-import {BlockScrollStrategy, Overlay, OverlayRef, ViewportRuler} from '@angular/cdk/overlay';
+import {BlockScrollStrategy, Overlay, OverlayRef, ScrollStrategy, ViewportRuler} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
 
 
@@ -28,7 +28,7 @@ export class MatMultiSortTableSettingsComponent implements OnInit {
   closeDialogOnChoice = true;
 
   @Input()
-  scrollStrategy = new BlockScrollStrategy(this.viewportRuler, document);
+  scrollStrategy: ScrollStrategy = new BlockScrollStrategy(this.viewportRuler, document);
 
   @Input()
   set tableData(tableData: TableData<any>) {

--- a/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
+++ b/projects/mat-multi-sort/src/lib/mat-multi-sort-table-settings/mat-multi-sort-table-settings.component.ts
@@ -1,7 +1,7 @@
 import {Component, ContentChild, ElementRef, Input, OnInit, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import { TableData } from '../table-data';
-import {Overlay, OverlayRef} from '@angular/cdk/overlay';
+import {BlockScrollStrategy, Overlay, OverlayRef, ViewportRuler} from '@angular/cdk/overlay';
 import {TemplatePortal} from '@angular/cdk/portal';
 
 
@@ -28,12 +28,15 @@ export class MatMultiSortTableSettingsComponent implements OnInit {
   closeDialogOnChoice = true;
 
   @Input()
+  scrollStrategy = new BlockScrollStrategy(this.viewportRuler, document);
+
+  @Input()
   set tableData(tableData: TableData<any>) {
     this._tableData = tableData;
   }
 
 
-  constructor(private overlay: Overlay, private viewContainerRef: ViewContainerRef) { }
+  constructor(private overlay: Overlay, private viewContainerRef: ViewContainerRef, private viewportRuler: ViewportRuler) { }
 
   ngOnInit(): void {
     this.sort = this.getSort();
@@ -56,14 +59,12 @@ export class MatMultiSortTableSettingsComponent implements OnInit {
         overlayX: 'end',
         overlayY: 'top'
       }]);
-
-    const scrollStrategy = this.overlay.scrollStrategies.block();
     this.overlayRef = this.overlay.create({
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-transparent-backdrop',
       panelClass: 'column-overlay',
       positionStrategy,
-      scrollStrategy
+      scrollStrategy: this.scrollStrategy
     });
     const templatePortal = new TemplatePortal(this.templateRef, this.viewContainerRef);
     this.overlayRef.attach(templatePortal);


### PR DESCRIPTION
Hello,

I have another small PR for making the scrollStrategy of the overlay configurable. The default value is BlockScrollStrategy, just like before, but in some cases another value might be desirable (since Block disables scrolling on the main container), hence the ability to @Input this option. I also updated the Readme to reflect this change.

Would be great if you could take a look at it, in case I missed something :)